### PR TITLE
Fix: Correct grand total calculation

### DIFF
--- a/src/utils/invoiceCalculations.js
+++ b/src/utils/invoiceCalculations.js
@@ -9,10 +9,9 @@ export const calculateTaxAmount = (subTotal, taxPercentage) => {
 };
 
 export const calculateGrandTotal = (subTotal, taxPercentage) => {
-  return (
-    parseFloat(subTotal).toFixed(2) +
-    calculateTaxAmount(subTotal, taxPercentage)
-  );
+  const taxAmount = calculateTaxAmount(subTotal, taxPercentage);
+  const grandTotal = parseFloat(subTotal) + parseFloat(taxAmount);
+  return grandTotal.toFixed(2);
 };
 
 export const generateGSTNumber = () => {

--- a/src/utils/invoiceCalculations.test.js
+++ b/src/utils/invoiceCalculations.test.js
@@ -1,0 +1,16 @@
+import { calculateGrandTotal } from './invoiceCalculations.js';
+import assert from 'assert';
+
+function testCalculateGrandTotal() {
+  const result = calculateGrandTotal('100.00', 10);
+  const expected = '110.00';
+  assert.strictEqual(result, expected, `Expected ${expected}, but got ${result}`);
+  console.log('testCalculateGrandTotal passed.');
+}
+
+try {
+  testCalculateGrandTotal();
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
The `calculateGrandTotal` function was incorrectly concatenating strings instead of adding numbers, leading to incorrect grand totals.

This commit fixes the bug by ensuring that the subtotal and tax amount are both treated as numbers and added together before being formatted as a string.

A new test file, `src/utils/invoiceCalculations.test.js`, is also added to verify the fix and prevent future regressions.